### PR TITLE
Update distribute_setup.py

### DIFF
--- a/distribute_setup.py
+++ b/distribute_setup.py
@@ -47,7 +47,7 @@ except ImportError:
         return os.spawnl(os.P_WAIT, sys.executable, *args) == 0
 
 DEFAULT_VERSION = "0.6.25"
-DEFAULT_URL = "http://pypi.python.org/packages/source/d/distribute/"
+DEFAULT_URL = "https://pypi.python.org/packages/source/d/distribute/"
 SETUPTOOLS_FAKED_VERSION = "0.6c11"
 
 SETUPTOOLS_PKG_INFO = """\


### PR DESCRIPTION
Use SSL for pi repository to fix problem noted in issue #5. I (and others) have made this fix locally and it seems to work.